### PR TITLE
Refactor LLM provider configuration

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,32 @@
 {
+  "llm_providers": {
+    "openai": {
+      "type": "openai",
+      "api_key_env": "OPENAI_API_KEY"
+    },
+    "anthropic": {
+      "type": "anthropic",
+      "api_key_env": "ANTHROPIC_API_KEY"
+    },
+    "deepinfra": {
+      "type": "openai_compatible",
+      "api_key_env": "DEEPINFRA_API_KEY",
+      "base_url": "https://api.deepinfra.com/v1/openai"
+    },
+    "deepseek": {
+      "type": "openai_compatible",
+      "api_key_env": "DEEPSEEK_API_KEY",
+      "base_url": "https://api.deepseek.com"
+    }
+  },
+  "model_provider_mapping": {
+    "gpt-4o-mini": "openai",
+    "gpt-4": "openai",
+    "claude-3-opus-20240229": "anthropic",
+    "claude-3-haiku-20240307": "anthropic",
+    "meta-llama/Meta-Llama-3-70B-Instruct": "deepinfra",
+    "deepseek-chat": "deepseek"
+  },
   "batch_generation": {
     "num_stories": 60,
     "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",

--- a/utils/inference.py
+++ b/utils/inference.py
@@ -1,122 +1,109 @@
 import os
-import openai
 import anthropic
-import aiohttp
 import json
 from typing import Optional, Dict, Any
 from openai import AsyncOpenAI
 import asyncio
-import requests
+
+# Config Loading
+_config = None
+_model_mapping = None
+_providers = None
+
+def _load_config():
+    """Load the inference configuration from config.json."""
+    global _config, _model_mapping, _providers
+    if _config is None:
+        try:
+            with open("config.json", "r") as f:
+                _config = json.load(f)
+            _providers = _config.get("llm_providers", {})
+            _model_mapping = _config.get("model_provider_mapping", {})
+            if not _providers or not _model_mapping:
+                raise ValueError("`llm_providers` or `model_provider_mapping` is missing from config.json")
+        except FileNotFoundError:
+            raise FileNotFoundError("config.json not found. Please ensure it exists in the project directory.")
+        except json.JSONDecodeError:
+            raise ValueError("config.json is not a valid JSON file.")
+
 
 async def generate_text(model: str, prompt: str, max_tokens: int = 8000, temperature: float = 0) -> str:
     """
-    Asynchronously generate text using various AI models.
+    Asynchronously generate text using a provider defined in config.json.
+
+    This function reads the configured model, determines the correct provider for the
+    given model, and makes the API call. It handles both OpenAI-compatible APIs
+    and special cases like Anthropic within this single function.
     
-    :param model: The name of the model to use (e.g., "gpt-3.5-turbo", "claude-2", "meta-llama/Llama-2-70b-chat-hf")
+    :param model: The name of the model to use (must be defined in config.json)
     :param prompt: The input prompt for text generation
     :param max_tokens: Maximum number of tokens to generate
-    :param temperature: Controls randomness in generation (0.0 to 1.0)
+    :param temperature: Controls randomness in generation
     :return: Generated text as a string
     """
-    
-    # OpenAI models
-    if model.startswith("o1") or model.startswith("o3") or model.startswith("o4"):
-        openai_api_key = os.getenv('OPENAI_API_KEY')
-        if not openai_api_key:
-            raise ValueError("OPENAI_API_KEY environment variable is not set")
-            
-        async_openai_client = AsyncOpenAI(api_key=openai_api_key)
-        
-        response = await async_openai_client.chat.completions.create(
-            model=model,
-            messages=[{"role": "user", "content": prompt}],
-          
-        )
-        return response.choices[0].message.content.strip()
-    
-    elif model.startswith("gpt-"):
-        openai_api_key = os.getenv('OPENAI_API_KEY')
-        if not openai_api_key:
-            raise ValueError("OPENAI_API_KEY environment variable is not set")
-            
-        async_openai_client = AsyncOpenAI(api_key=openai_api_key)
-        
-        response = await async_openai_client.chat.completions.create(
-            model=model,
-            messages=[{"role": "user", "content": prompt}],
-            max_tokens=max_tokens,
-            temperature=temperature
-        )
-        return response.choices[0].message.content.strip()
-    
-    # Anthropic (Claude) models
-    elif model.startswith("claude-"):
-        anthropic_api_key = os.getenv('ANTHROPIC_API_KEY')
-        if not anthropic_api_key:
-            raise ValueError("ANTHROPIC_API_KEY environment variable is not set")
-            
-        async def run_anthropic():
-            client = anthropic.Anthropic(api_key=anthropic_api_key)
-            if model.startswith("claude-3"):
-                response = client.messages.create(
-                    model=model,
-                    messages=[{"role": "user", "content": prompt}],
-                    max_tokens=max_tokens,
-                    temperature=temperature
-                )
-                return response.content[0].text.strip()
-            else:
-                response = client.completions.create(
-                    model=model,
-                    prompt=f"Human: {prompt}\n\nAssistant:",
-                    max_tokens_to_sample=max_tokens,
-                    temperature=temperature
-                )
-                return response.completion.strip()
-        
-        return await run_anthropic()
-    
-    # DeepInfra models
-    elif model.startswith("meta-llama/") or model.startswith("deepseek-ai") or model.startswith("Qwen/") or model.startswith("Meta-Llama"):
-        deepinfra_api_key = os.getenv('DEEPINFRA_API_KEY')
-        if not deepinfra_api_key:
-            raise ValueError("DEEPINFRA_API_KEY environment variable is not set")
-            
-        deepinfra_client = AsyncOpenAI(
-            api_key=deepinfra_api_key,
-            base_url="https://api.deepinfra.com/v1/openai"
-        )
-        
-        response = await deepinfra_client.chat.completions.create(
-            model=model,
-            messages=[{"role": "user", "content": prompt}],
-            max_tokens=max_tokens,
-            temperature=temperature
-        )
-        return response.choices[0].message.content.strip()
-    
-    # DeepSeek models
-    elif model.startswith("deepseek-"):
-        deepseek_api_key = os.getenv('DEEPSEEK_API_KEY')
-        if not deepseek_api_key:
-            raise ValueError("DEEPSEEK_API_KEY environment variable is not set")
-            
-        deepseek_client = AsyncOpenAI(
-            api_key=deepseek_api_key,
-            base_url="https://api.deepseek.com"
-        )
-        
-        try:
-            response = await deepseek_client.chat.completions.create(
+    _load_config()
+
+    # 1. Find the provider for the requested model
+    provider_name = _model_mapping.get(model)
+    if not provider_name:
+        raise ValueError(f"Model '{model}' not found in 'model_provider_mapping' in config.json.")
+
+    # 2. Get the configuration for that provider
+    provider_config = _providers.get(provider_name)
+    if not provider_config:
+        raise ValueError(f"Provider '{provider_name}' for model '{model}' not found in 'llm_providers' in config.json.")
+
+    # 3. Get the API key from environment variables
+    api_key_env = provider_config.get("api_key_env")
+    if api_key_env == "":
+        api_key = "dummy-key"
+    else:
+        api_key = os.getenv(api_key_env)
+        if not api_key:
+            raise ValueError(f"API key environment variable '{api_key_env}' is not set.")
+
+    provider_type = provider_config.get("type")
+    # 4. Handle generation based on provider type within this function
+    try:
+        if provider_type in ["openai", "openai_compatible"]:
+            client = AsyncOpenAI(
+                api_key=api_key,
+                base_url=provider_config.get("base_url")  # Works for both OpenAI and compatible APIs
+            )
+            response = await client.chat.completions.create(
                 model=model,
                 messages=[{"role": "user", "content": prompt}],
                 max_tokens=max_tokens,
                 temperature=temperature
             )
             return response.choices[0].message.content.strip()
-        except Exception as e:  
-            print(f"An error occurred while generating text with DeepSeek model: {e}")
-            raise
-    
-    else:
-        raise ValueError(f"Unsupported model: {model}")
+
+        elif provider_type == "anthropic":
+            client = anthropic.Anthropic(api_key=api_key)
+            
+            async def do_request():
+                if "claude-3" in model: # Use new API
+                    response = client.messages.create(
+                        model=model,
+                        messages=[{"role": "user", "content": prompt}],
+                        max_tokens=max_tokens,
+                        temperature=temperature
+                    )
+                    return response.content[0].text.strip()
+                else: # Use legacy API
+                    response = client.completions.create(
+                        model=model,
+                        prompt=f"\n\nHuman: {prompt}\n\nAssistant:",
+                        max_tokens_to_sample=max_tokens,
+                        temperature=temperature
+                    )
+                    return response.completion.strip()
+
+            return await do_request()
+
+        else:
+            raise ValueError(f"Unsupported provider type '{provider_type}' for provider '{provider_name}'.")
+            
+    except Exception as e:
+        print(f"An error occurred while generating text with model '{model}' from provider '{provider_name}': {e}")
+        raise


### PR DESCRIPTION
Moves LLM provider API details and model-to-provider mapping to `config.json`.

The `generate_text` utility now dynamically loads and utilizes this configuration, eliminating hardcoded provider logic. This change improves flexibility and maintainability by allowing new models and providers to be integrated or modified via configuration, rather than requiring code changes. It supports OpenAI, Anthropic, and various OpenAI-compatible endpoints. This also allows users to set their own OpenAI-compatible endpoint, rather than locking them to the provided endpoints.